### PR TITLE
UPDATECLI: Update Nixpkgs Unstable

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -95,9 +95,9 @@
         "repo": "nixpkgs"
       },
       "branch": "nixos-unstable",
-      "revision": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
-      "url": "https://github.com/NixOS/nixpkgs/archive/d3c42f187194c26d9f0309a8ecc469d6c878ce33.tar.gz",
-      "hash": "0bmnxsn9r4qfslg4mahsl9y9719ykifbazpxxn1fqf47zbbanxkh"
+      "revision": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+      "url": "https://github.com/NixOS/nixpkgs/archive/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507.tar.gz",
+      "hash": "1968wcqnb5gb947js0kv17hy15nc5817ra66nj33nc532d342ig0"
     },
     "nixvim": {
       "type": "Git",


### PR DESCRIPTION


Update Nixpkgs Unstable using npins.

---



<Actions>
    <action id="54fc97ca47abc60df4c9beaf09b7051d24e8c65d0fea274db0e05275774673d9">
        <h3>Nixpkgs Unstable Update</h3>
        <details id="37a8eec1ce19687d132fe29051dca629d164e2c4958ba141d5f4133a33f0688f">
            <summary>npins nixpkgs-unstable update</summary>
            <p>ran shell command &#34;nix-shell -p npins --command \&#34;npins update nixpkgs-unstable\&#34; &amp;&amp; echo d3c42f187194c26d9f0309a8ecc469d6c878ce33&#34;</p>
        </details>
        <a href="https://github.com/didactiklabs/nixbook/actions/runs/12451883818">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

