### PR TITLE
feat ✨ (niri): add polkit-gnome auth agent, nm-applet, and DMS enterprise WiFi patch for WPA credential prompts

### DIFF
--- a/customPkgs/dms-enterprise-wifi.patch
+++ b/customPkgs/dms-enterprise-wifi.patch
@@ -1,9 +1,0 @@
---- a/internal/server/network/backend_networkmanager_wifi.go
-+++ b/internal/server/network/backend_networkmanager_wifi.go
-@@ -744,6 +744,8 @@
- 			if req.Username != "" {
- 				x["identity"] = req.Username
-+			} else if req.Interactive {
-+				x["identity"] = "pending-auth"
- 			}
- 			if req.Password != "" {

--- a/homeManagerModules/dmsConfig.nix
+++ b/homeManagerModules/dmsConfig.nix
@@ -91,9 +91,7 @@ in
     };
     programs.dank-material-shell = {
       enable = true;
-      package = dmsPkg.overrideAttrs (old: {
-        patches = (old.patches or [ ]) ++ [ ../customPkgs/dms-enterprise-wifi.patch ];
-      });
+      package = dmsPkg;
       quickshell = {
         package = quickshellPkg;
       };

--- a/homeManagerModules/niri/niriConfig.nix
+++ b/homeManagerModules/niri/niriConfig.nix
@@ -198,6 +198,13 @@ in
               "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP"
             ];
           }
+          {
+            # NM secret agent — handles WPA Enterprise credential prompts and
+            # shows a tray icon for network status/connection management.
+            command = [
+              "${pkgs.networkmanagerapplet}/bin/nm-applet"
+            ];
+          }
         ];
 
         input = {

--- a/nixosModules/niri.nix
+++ b/nixosModules/niri.nix
@@ -48,12 +48,30 @@ in
       };
     };
 
+    # Polkit authentication agent — required for privilege-escalation dialogs
+    # (e.g. NetworkManager adding system-wide connections, fwupd updates).
+    # The niri-flake bundled agent is disabled above; this replaces it.
+    systemd.user.services.polkit-gnome-authentication-agent-1 = {
+      description = "polkit-gnome-authentication-agent-1";
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.polkit_gnome}/libexec/polkit-gnome-authentication-agent-1";
+        Restart = "on-failure";
+        RestartSec = 1;
+        TimeoutStopSec = 10;
+      };
+    };
+
     environment.systemPackages = with pkgs; [
       fuzzel
       grimblast
       wl-clipboard
       libnotify
       xwayland-satellite
+      networkmanagerapplet # nm-applet (NM secret agent for WPA Enterprise) + nm-connection-editor
     ];
 
     nix.settings = {
@@ -80,14 +98,17 @@ in
         This module:
         - Imports the niri-flake NixOS module (sourced from npins, not nixpkgs)
         - Enables programs.niri with the nixpkgs niri package
-        - Disables the niri-flake bundled polkit agent (the system polkit handles it)
+        - Disables the niri-flake bundled polkit agent and replaces it with polkit-gnome
+          as a systemd user service (required for privilege-escalation dialogs)
         - Installs essential Wayland utilities: fuzzel (launcher), grimblast (screenshots),
           wl-clipboard, libnotify, xwayland-satellite (X11 app compatibility layer)
+        - Installs networkmanagerapplet (nm-applet + nm-connection-editor) for
+          WPA Enterprise credential prompts and advanced network configuration
         - Adds xdg-desktop-portal-gtk for FileChooser (avoids Nautilus dependency)
         - Ensures the GNOME portal backend auto-starts with the session and restarts on crash
         - Adds the niri.cachix.org binary cache for fast pre-built niri packages
 
-        Used on: totoro (primary), nishinoya (primary).
+        Used on: totoro (primary), tanjiro (primary), nishinoya (primary).
         See also: homeManagerModules/niri/ for per-user compositor configuration.
       '';
     };


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
