### PR TITLE
rdfbfg

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775848233,
-        "narHash": "sha256-+V6K66AsFCxD0PmKOASSSFUdEjmAtIwX4XlQ+2JBrmk=",
+        "lastModified": 1776332500,
+        "narHash": "sha256-jIofY8pEbN6Ed7hOj6XYiVC2+Adr7syCMPGY2S4fxwI=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "cf4f57c61f5dc9d58300bdf18102d9cf5b4f29ea",
+        "rev": "d7288c178c6b56973bb8abda642f300d21de1afb",
         "type": "github"
       },
       "original": {
@@ -78,17 +78,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       }
     },

--- a/nixosModules/tailscale.nix
+++ b/nixosModules/tailscale.nix
@@ -131,17 +131,9 @@ in
     services.tailscale = {
       enable = true;
     };
+    # Enable IPv6 forwarding for exit node / subnet routing support.
     boot.kernel.sysctl = {
-      # Enable IPv6 forwarding for exit node / subnet routing support.
       "net.ipv6.conf.all.forwarding" = 1;
-      # Override the strict rp_filter (= 1) set in core.nix.
-      # Linux takes max(all, per-interface) for rp_filter, so even though
-      # checkReversePath = "loose" sets per-interface values, the global
-      # all.rp_filter = 1 from core.nix wins and silently drops asymmetric
-      # return traffic — which is exactly what exit-node usage produces
-      # (packets arrive on tailscale0 but replies leave via the physical NIC).
-      "net.ipv4.conf.all.rp_filter" = lib.mkForce 2;
-      "net.ipv4.conf.default.rp_filter" = lib.mkForce 2;
     };
     networking.firewall = {
       # Always allow traffic from the Tailscale network.


### PR DESCRIPTION
- **chore(devenv): update devenv and nixpkgs pinned dependencies**
- **Revert "fix 🐛 (tailscale): add rp_filter override to fix exit node asymmetric routing"**
