### PR TITLE
chore 🧹 (homeManagerModules): remove dgop package and alias

### DIFF
--- a/homeManagerModules/commonShellConfig.nix
+++ b/homeManagerModules/commonShellConfig.nix
@@ -12,7 +12,6 @@ in
     pkgs.sd # sed alternative
     pkgs.viddy # watch alternative
     witr
-    pkgs.dgop
     pkgs.devenv
   ];
 
@@ -20,7 +19,6 @@ in
     ks = "kswitch";
     watch = "viddy";
     y = "yazi";
-    top = "dgop";
     df = "duf";
     cd = "z";
     neofetch = "fastfetch";


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
