### PR TITLE
fix 🐛 (gamingConfig): fix proton-cachyos src hash mismatch from upstream tarball rebuild

### DIFF
--- a/nixosModules/gamingConfig.nix
+++ b/nixosModules/gamingConfig.nix
@@ -19,6 +19,14 @@ let
     }).defaultNix.packages.${pkgs.stdenv.hostPlatform.system}.proton-cachyos
     ).overrideAttrs
       (old: {
+        # CachyOS rebuilt the proton-cachyos-slr tarball in place (same version
+        # number, new bytes), so the hash pinned in upstream's versions.json is
+        # stale and the fixed-output `src` fetch fails with a hash mismatch.
+        # Override the src fetch hash to the artifact the mirror currently serves
+        # until upstream bumps versions.json.
+        src = old.src.overrideAttrs (_: {
+          outputHash = "sha256-9yjERUgfJag40ipOWennnD9vCRC+pQ+o3czjUU2TlCQ=";
+        });
         outputs = [
           "out"
           "steamcompattool"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -307,9 +307,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "7da792f0d6787dad64ae501e36b5adbd3b2c8d6e",
-      "url": "https://github.com/Shochraos/nix-proton-cachyos/archive/7da792f0d6787dad64ae501e36b5adbd3b2c8d6e.tar.gz",
-      "hash": "sha256-6gKIbE+GQFVdFZwyQlzwOb4LHJyNEVnp9nYfSBjbcMY="
+      "revision": "7470cb98014a18a0784875ca8bc7c7840ec2e7e3",
+      "url": "https://github.com/Shochraos/nix-proton-cachyos/archive/7470cb98014a18a0784875ca8bc7c7840ec2e7e3.tar.gz",
+      "hash": "sha256-CenJWz6QBLPVeAK4CXWROuYOWZc8tx95K0zH1lR+sM8="
     },
     "nixos-hardware": {
       "type": "Git",


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
