### PR TITLE
fix 🐛 (zen-browser): fix domain whitelist typo and remove unused entries

### DIFF
--- a/homeManagerModules/zenBrowserConfig.nix
+++ b/homeManagerModules/zenBrowserConfig.nix
@@ -158,9 +158,7 @@ in
           "browser.tabs.restorePinnedTabs.onStartup" = true;
 
           # Golinks - treat "go" as a valid domain so go/foo resolves to http://go/foo
-          "browser.fixup.domainwhitelist.g" = true;
-          "browser.fixup.domainwhitelist.b" = true;
-          "browser.fixup.domainwhitelist.w" = true;
+          "browser.fixup.domainwhitelist.go" = true;
 
           # URL bar
           "browser.urlbar.suggest.searches" = true;


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
