### PR TITLE
chore 🧹 (ci): harden CI workflows: disable fail-fast on build matrix and skip frozen pins in npins-update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,10 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: self-hosted
     strategy:
+      # Don't cancel the other profiles when one runner hiccups (e.g. a runner
+      # shutdown signal or a transient "SQLite database is busy" lock race on the
+      # shared self-hosted Nix store). Each profile's build is independent.
+      fail-fast: false
       max-parallel: 3
       matrix:
         profile:

--- a/.github/workflows/npins-update.yaml
+++ b/.github/workflows/npins-update.yaml
@@ -55,7 +55,9 @@ jobs:
         uses: actions/checkout@v4
       - id: set-pins
         run: |
-          PINS=$(jq -c '.pins | keys' npins/sources.json)
+          # Exclude frozen pins: `npins update <pin>` refuses to update a frozen
+          # pin and exits 1, which would fail that matrix leg on every run.
+          PINS=$(jq -c '.pins | to_entries | map(select(.value.frozen != true) | .key)' npins/sources.json)
           echo "pins=$PINS" >> "$GITHUB_OUTPUT"
   npins-update:
     needs: get-pins


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
