### PR TITLE
fix: build niri against libdisplay-info 0.2.0 and refresh proton-cachyos-slr hash

### DIFF
--- a/nixosModules/overlays.nix
+++ b/nixosModules/overlays.nix
@@ -14,6 +14,15 @@ in
     nix-fast-build
     ;
 
+  # nixpkgs bumped the default `libdisplay-info` to 0.4.0, but niri 26.04 (and
+  # even niri main) still constrains `libdisplay-info = "0.3.0"` in Cargo.toml,
+  # which via the `libdisplay-info-sys` crate requires the C library `< 0.4.0`.
+  # Building `pkgs.niri` therefore fails at the pkg-config check. nixpkgs keeps
+  # the compatible 0.2.0 around as the versioned attribute `libdisplay-info_0_2`
+  # (this is exactly what upstream niri-flake passes), so build niri against it.
+  # Remove once niri upstream supports libdisplay-info 0.4.0.
+  niri = prev.niri.override { libdisplay-info = final.libdisplay-info_0_2; };
+
   # Fix upstream hash mismatch: the GitHub-generated patch for PR #23326
   # changed content, breaking the pinned hash in nixpkgs.
   openapi-generator-cli = prev.openapi-generator-cli.overrideAttrs (oldAttrs: {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -393,9 +393,9 @@
     },
     "proton-cachyos-slr": {
       "type": "Url",
-      "url": "https://mirror.cachyos.org/repo/x86_64/cachyos/proton-cachyos-slr-1:11.0.20260702-1-x86_64.pkg.tar.zst",
+      "url": "https://mirror.cachyos.org/repo/x86_64/cachyos/proton-cachyos-slr-1:11.0.20260703-1-x86_64.pkg.tar.zst",
       "unpack": false,
-      "hash": "sha256-KohxHuynvab6yNQiUKs2W1FJIetc7DfxbN4e+ee7S6c="
+      "hash": "sha256-T6coXzRxjHmcLkbsmVnO5wIRkO5pxHi9CARcqqDlwL0="
     },
     "pvmigrate": {
       "type": "GitRelease",


### PR DESCRIPTION
## Problem

All niri machines (tanjiro, totoro, nishinoya, hanamichi) failed to build:

```
Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
```

nixpkgs bumped the default `libdisplay-info` C library to **0.4.0**, but niri 26.04 (and even niri `main`) still declare `libdisplay-info = "0.3.0"` in `Cargo.toml`, which the `libdisplay-info-sys` crate resolves to `< 0.4.0`. Building `pkgs.niri` therefore fails at the pkg-config check.

## Fix

Override niri to build against nixpkgs' versioned `libdisplay-info_0_2` (0.2.0) attribute — the same package upstream niri-flake passes to niri via `libdisplay-info_0_2 ? libdisplay-info`.

Note: switching to the `epireyn/niri-flake` fork was evaluated but does **not** fix this — its `niri-stable` fails with the same error (the fork actually removed upstream's `libdisplay-info_0_2` handling).

## Also

Refresh the `proton-cachyos-slr` npins pin: CachyOS rebuilt the tarball in place (`20260702` -> `20260703`), so the pinned fixed-output hash went stale and the gaming profiles (hanamichi, anya) failed with a hash mismatch.

## Verification

All 5 profiles build to completion locally via `colmena build --on <profile> --no-build-on-target`: totoro, tanjiro, nishinoya, hanamichi, anya.